### PR TITLE
Splits on '.' to expose nested properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,24 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+
+function accesorString(value) {
+	var depths = value.split(".");
+	var length = depths.length;
+	var result = "";
+	
+	for (var i = 0; i < length; i++) {
+		result += "[" + JSON.stringify(depths[i]) + "]";
+	}
+
+	return result;
+}
+
 module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
 	this.cacheable && this.cacheable();
 	if(!this.query) throw new Error("query parameter is missing");
 	return "module.exports = " +
-		"global[" + JSON.stringify(this.query.substr(1)) + "] = " +
+		"global" + accesorString(this.query.substr(1)) + " = " +
 		"require(" + JSON.stringify("-!" + remainingRequest) + ");";
 };


### PR DESCRIPTION
Currently exposing `require('expose?GlobalProperty.NestedProperty!./Something');` results in `Global["GlobalProperty.NestedProperty"]` this change will allow nested properties `Global["GlobalProperty"]["NestedProperty"]`
