### PR TITLE
Fix inconsistent hashes when using expose-loader for builds in different dirs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 	Author Tobias Koppers @sokra
 */
 
+var path = require('path');
+
 function accesorString(value) {
 	var childProperties = value.split(".");
 	var length = childProperties.length;
@@ -21,8 +23,12 @@ function accesorString(value) {
 
 module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
+	// Change the request from an /abolute/path.js to a relative ./path.js
+	// This prevents [chunkhash] values from changing when running webpack
+	// builds in different directories.
+	var newRequestPath = "." + path.sep + path.basename(remainingRequest);
 	this.cacheable && this.cacheable();
 	if(!this.query) throw new Error("query parameter is missing");
 	return accesorString(this.query.substr(1)) + " = " +
-		"require(" + JSON.stringify("-!" + remainingRequest) + ");";
+		"require(" + JSON.stringify("-!" + newRequestPath) + ");";
 };


### PR DESCRIPTION
This fixes an issue created by the loader when building projects in different
files. The expose-loader was previously changing requests to modules to
absolute paths, which caused equivalent builds to generate different hashes
when run in different directories.

The fix basically converts the new requests to relative paths, that are
relative to the original request.