### PR TITLE
Fix issue when multiple variables are exposed for the same request.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,10 @@ module.exports.pitch = function(remainingRequest) {
 	// Change the request from an /abolute/path.js to a relative ./path.js
 	// This prevents [chunkhash] values from changing when running webpack
 	// builds in different directories.
-	var newRequestPath = "." + path.sep + path.basename(remainingRequest);
+	const newRequestPath = remainingRequest.replace(
+		this.resourcePath,
+		'.' + path.sep + path.relative(this.context, this.resourcePath)
+	);
 	this.cacheable && this.cacheable();
 	if(!this.query) throw new Error("query parameter is missing");
 	return accesorString(this.query.substr(1)) + " = " +


### PR DESCRIPTION
The previous commit for more consistent hashes naively overwrote the
entire request, assuming there weren't additional loaders to be run
against the file.  This modifies the changes to the request to only change
the path to the imported file rather than changing the entire
remainingRequest.

This is an attempt at fixing - https://github.com/webpack-contrib/expose-loader/issues/29


Also, I was worried that I might bork something else, so I created a repo here for quickly testing - https://github.com/gdborton/expose-loader-test