### PR TITLE
docs(readme): updates for JSF maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,29 @@
-# expose loader for webpack
+[![npm][npm]][npm-url]
+[![deps][deps]][deps-url]
+[![chat][chat]][chat-url]
 
-The expose loader adds modules to the global object. This is useful
+<div align="center">
+  <!-- replace with accurate logo e.g from https://worldvectorlogo.com/ -->
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200" vspace="" hspace="25"
+      src="https://cdn.rawgit.com/webpack/media/e7485eb2/logo/icon.svg">
+  </a>
+  <h1>Expose Loader</h1>
+  <p>The expose loader adds modules to the global object. This is useful
 for debugging, or supporting libraries that depend on libraries in
-globals.
+globals.<p>
+</div>
+
+<h2 align="center">Install</h2>
+
+```bash
+npm i eslint-config-webpack --save
+```
+
+<h2 align="center">Usage</h2>
 
 **Note**: Modules must be `require()`'d within in your bundle, or they will not
 be exposed.
-
-## Usage
 
 ``` javascript
 require("expose-loader?libraryName!./file.js");
@@ -50,6 +66,45 @@ bundle.
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
 
-## License
+<h2 align="center">Maintainers</h2>
 
-MIT (http://www.opensource.org/licenses/mit-license.php)
+<table>
+  <tbody>
+    <tr>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/166921?v=3&s=150">
+        </br>
+        <a href="https://github.com/bebraw">Juho Vepsäläinen</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars2.githubusercontent.com/u/8420490?v=3&s=150">
+        </br>
+        <a href="https://github.com/d3viant0ne">Joshua Wiens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/533616?v=3&s=150">
+        </br>
+        <a href="https://github.com/SpaceK33z">Kees Kluskens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/3408176?v=3&s=150">
+        </br>
+        <a href="https://github.com/TheLarkInn">Sean Larkin</a>
+      </td>
+    </tr>
+  <tbody>
+</table>
+
+
+[npm]: https://img.shields.io/npm/v/expose-loader.svg
+[npm-url]: https://npmjs.com/package/expose-loader
+
+[deps]: https://david-dm.org/webpack-contrib/expose-loader.svg
+[deps-url]: https://david-dm.org/webpack-contrib/expose-loader
+
+[chat]: https://img.shields.io/badge/gitter-webpack%2Fwebpack-brightgreen.svg
+[chat-url]: https://gitter.im/webpack/webpack


### PR DESCRIPTION
As part of the effort to reach compliance with JSF and get the CLA bot enabled, maintainers need to be clearly displayed.

While I was at it, I did the updates to the readme using the template chosen for the standards effort.