### PR TITLE
docs(README): remove outdated React references

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ require("expose-loader?libraryName!./file.js");
 // In web browsers, window.libraryName is then available.
 ```
 
-This line works to expose React to the web browser to enable the Chrome React devtools:
+For example, let's say you want to expose jQuery as a global called `$`:
 
 ```
-require("expose-loader?React!react");
+require("expose-loader?$!jquery");
 ```
 
-Thus, `window.React` is then available to the Chrome React devtools extension.
+Thus, `window.$` is then available in the browser console.
 
 Alternately, you can set this in your config file:
 
@@ -45,7 +45,7 @@ webpack v1 usage
 ```
 module: {
   loaders: [
-    { test: require.resolve("react"), loader: "expose-loader?React" }
+    { test: require.resolve("jquery"), loader: "expose-loader?$" }
   ]
 }
 ```
@@ -53,15 +53,17 @@ webpack v2 usage
 ```
 module: {
   rules: [{
-          test: require.resolve('react'),
+          test: require.resolve('jquery'),
           use: [{
               loader: 'expose-loader',
-              options: 'React'
+              options: '$'
           }]
       }]
 }
 ```
-Also for multiple expose you can use `!` in loader string:
+
+Let's say you also want to expose it as `window.jQuery` in addition to `window.$`.
+For multiple expose you can use `!` in loader string:
 
 webpack v1 usage
 ```


### PR DESCRIPTION
This is outdated:

>This line works to expose React to the web browser to enable the Chrome React devtools:

React has worked with DevTools without exposing globals for a long time so I just ported the whole example to use the same demo consistently (jQuery).