### PR TITLE
docs(README): fix broken link (`#globals_require_resolve` => `#modules_require_resolve`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ module: {
 }
 ```
 
-The [`require.resolve`](https://nodejs.org/api/all.html#globals_require_resolve)
+The [`require.resolve`](https://nodejs.org/api/all.html#modules_require_resolve)
 is a Node.js call (unrelated to `require.resolve` in webpack
 processing). `require.resolve` gives you the
 absolute path to the module (`"/.../app/node_modules/react/react.js"`). So the


### PR DESCRIPTION
Hi!

Just fix broken link in the README.md 👾
