### PR TITLE
fix: make sure `userRequest` stays unique (`module.userRequest`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,13 @@ module.exports.pitch = function(remainingRequest) {
 	);
 	this.cacheable && this.cacheable();
 	if(!this.query) throw new Error("query parameter is missing");
+    /*
+     * Workaround until module.libIdent() in webpack/webpack handles this correctly.
+     *
+     * fixes:
+     * - https://github.com/webpack-contrib/expose-loader/issues/55
+     * - https://github.com/webpack-contrib/expose-loader/issues/49
+     */
 	this._module.userRequest = this._module.userRequest + '-exposed';
 	return accesorString(this.query.substr(1)) + " = " +
 		"require(" + JSON.stringify("-!" + newRequestPath) + ");";

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports.pitch = function(remainingRequest) {
 	);
 	this.cacheable && this.cacheable();
 	if(!this.query) throw new Error("query parameter is missing");
+	this._module.userRequest = this._module.userRequest + '-exposed';
 	return accesorString(this.query.substr(1)) + " = " +
 		"require(" + JSON.stringify("-!" + newRequestPath) + ");";
 };


### PR DESCRIPTION
### `Notable Changes`

There is an issue using expose loader in combination with `webpack.NamedModulesPlugin` as the userRequest that is used by webpack to calculate the named modules id stays the same.

See images below for explanation and fix:

<img width="558" alt="screen shot 2017-11-14 at 11 09 46 am" src="https://user-images.githubusercontent.com/749171/32793934-fa1683e6-c92c-11e7-9772-910224d5549d.png">
<img width="522" alt="screen shot 2017-11-14 at 11 09 57 am" src="https://user-images.githubusercontent.com/749171/32793949-ffca536c-c92c-11e7-9f9b-bcb0ece38f7c.png">

### `Issues`

- Fixes #55 
- Fixes #49 