### PR TITLE
Fix: Absolute paths being used when expose-loader exposes more than one global for a library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ typings/
 /local
 /reports
 /node_modules
+/test/outputs
 .DS_Store
 Thumbs.db
 .idea

--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ module: {
     test: require.resolve('jquery'),
     use: [{
       loader: 'expose-loader',
-      options: 'jQuery'
-    },{
-      loader: 'expose-loader',
-      options: '$'
+      options: {
+        expose: ['jQuery', '$']
+      }
     }]
   }]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,10 @@
 
 const path = require('path');
 
+const exposeLoaderPathRegex = new RegExp(
+  `^(.*)${path.sep}expose-loader${path.sep}index.js`
+);
+
 function accesorString(value) {
   const childProperties = value.split('.');
   const { length } = childProperties;
@@ -25,10 +29,18 @@ module.exports.pitch = function pitch(remainingRequest) {
   // Change the request from an /abolute/path.js to a relative ./path.js
   // This prevents [chunkhash] values from changing when running webpack
   // builds in different directories.
-  const newRequestPath = remainingRequest.replace(
+  let newRequestPath = remainingRequest.replace(
     this.resourcePath,
     `.${path.sep}${path.relative(this.context, this.resourcePath)}`
   );
+  const exposeLoaderMatch = remainingRequest.match(exposeLoaderPathRegex);
+  if (exposeLoaderMatch) {
+    const exposeLoaderPath = exposeLoaderMatch[0];
+    newRequestPath = newRequestPath.replace(
+      exposeLoaderPath,
+      `.${path.sep}${path.relative(this.context, exposeLoaderPath)}`
+    );
+  }
 
   if (this.cacheable) {
     this.cacheable();

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,19 +9,19 @@ const exposeLoaderPathRegex = new RegExp(
   `^(.*)${path.sep}expose-loader${path.sep}index.js`
 );
 
-function accesorString(value) {
+function buildAccessorAndInitializersFor(value) {
   const childProperties = value.split('.');
   const { length } = childProperties;
   let propertyString = 'global';
-  let result = '';
+  const initializers = [];
 
   for (let i = 0; i < length; i++) {
-    if (i > 0) result += `if(!${propertyString}) ${propertyString} = {};\n`;
+    if (i > 0)
+      initializers.push(`if(!${propertyString}) ${propertyString} = {};`);
     propertyString += `[${JSON.stringify(childProperties[i])}]`;
   }
 
-  result += `module.exports = ${propertyString}`;
-  return result;
+  return [propertyString, initializers];
 }
 
 module.exports = function loader() {};
@@ -47,16 +47,34 @@ module.exports.pitch = function pitch(remainingRequest) {
   }
 
   if (!this.query) throw new Error('query parameter is missing');
+
+  let exposed;
+  if (typeof this.query === 'string') {
+    exposed = [this.query.substr(1)];
+  } else if (this.query.expose) {
+    exposed = this.query.expose;
+  }
+
   /*
-     * Workaround until module.libIdent() in webpack/webpack handles this correctly.
-     *
-     * fixes:
-     * - https://github.com/webpack-contrib/expose-loader/issues/55
-     * - https://github.com/webpack-contrib/expose-loader/issues/49
-     */
+   * Workaround until module.libIdent() in webpack/webpack handles this correctly.
+   *
+   * fixes:
+   * - https://github.com/webpack-contrib/expose-loader/issues/55
+   * - https://github.com/webpack-contrib/expose-loader/issues/49
+   */
   this._module.userRequest = `${this._module.userRequest}-exposed`;
+
+  let initializers = [];
+  const accessors = [];
+  exposed.forEach((value) => {
+    const [accessor, valueInitializers] = buildAccessorAndInitializersFor(
+      value
+    );
+    accessors.push(accessor);
+    initializers = initializers.concat(valueInitializers);
+  });
   return (
-    `${accesorString(this.query.substr(1))} = ` +
+    `${initializers.join('\n')}\nmodule.exports = ${accessors.join(' = ')} =` +
     `require(${JSON.stringify(`-!${newRequestPath}`)});`
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1705,15 +1705,6 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
-      }
-    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -2945,26 +2936,6 @@
         "which": "1.3.0"
       }
     },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
-      }
-    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -2997,9 +2968,9 @@
       "dev": true
     },
     "cssstyle": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
+      "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
       "dev": true,
       "requires": {
         "cssom": "0.3.2"
@@ -3052,7 +3023,7 @@
       "requires": {
         "abab": "1.0.4",
         "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.0"
+        "whatwg-url": "6.4.1"
       }
     },
     "date-fns": {
@@ -5477,18 +5448,6 @@
         "minimalistic-assert": "1.0.0"
       }
     },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "dev": true,
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6631,7 +6590,7 @@
       "requires": {
         "jest-mock": "22.4.3",
         "jest-util": "22.4.3",
-        "jsdom": "11.7.0"
+        "jsdom": "11.11.0"
       }
     },
     "jest-environment-node": {
@@ -7257,9 +7216,9 @@
       "optional": true
     },
     "jsdom": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.7.0.tgz",
-      "integrity": "sha512-9NzSc4Iz4gN9p4uoPbBUzro21QdgL32swaWIaWS8eEVQ2I69fRJAy/MKyvlEIk0V7HtKgfMbbOKyTZUrzR2Hsw==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
+      "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
@@ -7267,16 +7226,16 @@
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
+        "cssstyle": "0.3.1",
         "data-urls": "1.0.0",
         "domexception": "1.0.1",
         "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.2.0",
-        "nwmatcher": "1.4.4",
+        "left-pad": "1.3.0",
+        "nwsapi": "2.0.1",
         "parse5": "4.0.0",
         "pn": "1.1.0",
-        "request": "2.85.0",
+        "request": "2.87.0",
         "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
@@ -7285,7 +7244,7 @@
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
         "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.0",
+        "whatwg-url": "6.4.1",
         "ws": "4.1.0",
         "xml-name-validator": "3.0.0"
       }
@@ -7416,9 +7375,9 @@
       }
     },
     "left-pad": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
       "dev": true
     },
     "leven": {
@@ -8917,10 +8876,10 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "nwmatcher": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
-      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+    "nwsapi": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.1.tgz",
+      "integrity": "sha512-xOJJb7kAAGy6UOklbaIPA0iu/27VMHfAbMUgYJlXz4qRXytIkPGM2vwfbxa+tbaqcqHNsP6RN4eDZlePelWKpQ==",
       "dev": true
     },
     "oauth-sign": {
@@ -9649,9 +9608,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "querystring": {
@@ -9955,9 +9914,9 @@
       }
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
@@ -9968,7 +9927,6 @@
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
         "har-validator": "5.0.3",
-        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
@@ -9976,9 +9934,8 @@
         "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
@@ -10782,15 +10739,6 @@
         "kind-of": "3.2.2"
       }
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "dev": true,
-      "requires": {
-        "hoek": "4.2.1"
-      }
-    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -11181,12 +11129,6 @@
         "is-obj": "1.0.1",
         "is-regexp": "1.0.0"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -13013,9 +12955,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+      "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
       "dev": true,
       "requires": {
         "lodash.sortby": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "husky": "^0.14.3",
     "jest": "^22.4.3",
+    "jsdom": "^11.11.0",
     "lint-staged": "^7.0.4",
     "memory-fs": "^0.4.1",
     "nsp": "^3.2.1",

--- a/test/expose-loader.test.js
+++ b/test/expose-loader.test.js
@@ -1,0 +1,85 @@
+import path from 'path';
+
+import { JSDOM } from 'jsdom';
+
+import webpack from './helpers/compiler';
+
+const html = `
+  <!DOCTYPE html>
+  <script src="${path.resolve(
+    __dirname,
+    './outputs/exposeLoader/main.chunk.js'
+  )}"></script>
+  <script src="${path.resolve(
+    __dirname,
+    './outputs/exposeLoader/runtime~main.js'
+  )}"></script>
+  <body>
+    <h1>Hello, expose-loader!</h1>
+  </body>
+`;
+
+const isExposed = (window, ...exposedVars) =>
+  new Promise((resolve) => {
+    window.onload = () => {
+      exposedVars.forEach((key) => {
+        expect(window[key]).toBeDefined();
+        expect(window[key].hello()).toEqual('hello');
+      });
+      resolve();
+    };
+  });
+
+describe('expose-loader', () => {
+  test('Single global exposed', async () => {
+    const config = {
+      output: 'exposeLoader',
+      rules: [
+        {
+          test: path.resolve(__dirname, './fixtures/bar.js'),
+          use: {
+            loader: path.resolve(__dirname, '../lib/index.js'),
+            options: 'foo',
+          },
+        },
+      ],
+    };
+
+    await webpack('expose_fixture.js', config, { output: true });
+    const dom = new JSDOM(html, {
+      resources: 'usable',
+      runScripts: 'dangerously',
+    });
+    const window = dom.window;
+    await isExposed(window, 'foo');
+  });
+
+  test('Multiple globals exposed', async () => {
+    const config = {
+      output: 'exposeLoader',
+      rules: [
+        {
+          test: path.resolve(__dirname, './fixtures/bar.js'),
+          use: [
+            {
+              loader: path.resolve(__dirname, '../lib/index.js'),
+              options: 'foo',
+            },
+            {
+              loader: path.resolve(__dirname, '../lib/index.js'),
+              options: 'bar',
+            },
+          ],
+        },
+      ],
+    };
+
+    await webpack('expose_fixture.js', config, { output: true });
+    const dom = new JSDOM(html, {
+      resources: 'usable',
+      runScripts: 'dangerously',
+    });
+    const window = dom.window;
+    await isExposed(window, 'foo', 'bar');
+  });
+});

--- a/test/fixtures/bar.js
+++ b/test/fixtures/bar.js
@@ -1,0 +1,3 @@
+module.exports = {
+  hello: () => 'hello',
+};

--- a/test/fixtures/expose_fixture.js
+++ b/test/fixtures/expose_fixture.js
@@ -1,0 +1,1 @@
+import './bar';


### PR DESCRIPTION
When using expose launcher to expose more than one global for a library, e.g.
```javascript
loaders: [{
  test: require.resolve('jquery'),
  use: [
    {
      loader: 'expose-loader',
      options: '$'
    },
    {
      loader: 'expose-loader',
      options: 'jQuery'
    }
  ]
}]
```

the `remainingRequest` for one of the sources is a reference to the already-loaded libaray:
` /Users/foo/projects/bar/node_modules/expose-loader/index.js?jQuery!/Users/foo/projects/bar/node_modules/jquery/dist/jquery.js`

Since the existing logic doesn't change the path of the `expose-loader/index.js` file from absolute to relative, and this value is used in the webpack `chunkhash` value, we were experiencing miss-matched hashes for the same file if built from a differently-named directory.

The result of this PR would change the `require` in the return from this:
```javascript
require("/Users/foo/projects/bar/node_modules/expose-loader/index.js?jQuery!./jquery.js")
```
to this:
```javascript
require("./../../expose-loader/index.js?jQuery!./jquery.js")
```

### tl;dr
- adds an additional check for the expose-loader path
- if present, replaces the absolute expose-loader path with a relative path