### PR TITLE
fix(package): add `webpack >= v4.0.0` (`peerDependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/webpack-contrib/expose-loader",
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^3.0.0"
+    "webpack": "*"
   },
   "engines": {
     "node": ">= 4.3 < 5.0.0 || >= 5.10"


### PR DESCRIPTION
Webpack 4 alpha has been released. In preparation for v4,
it seems reasonable to change this to allow *. This should cut
down on maintenance and avoid unnecessarily blocking folks
from updating going forward.