### PR TITLE
Add comment to loader ordering best practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,28 @@ absolute path to the module (`"/.../app/node_modules/react/react.js"`). So the
 expose only applies to the react module. And it's only exposed when used in the
 bundle.
 
+------
+
+`expose-loader` creates a new entry file and moves the original. It is recommmended `expose-loader` rules come **before other rules** so that subsequent rules pick up all the files.
+```js
+// webpack.config.js
+module: {
+  rules: [
+    {
+      test: require.resolve('module-name'),
+      use: [{
+        loader: 'expose-loader',
+        options: 'moduleName',
+      }],
+    },
+    {
+      test: /\.m?js$/,
+      loader: 'babel-loader',
+    }
+  ]
+}
+```
+
 ## Contributing
 
 Please take a moment to read our contributing guidelines if you haven't yet done so.


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**
- [x] **Documentation update**

### Motivation / Use-Case

In our codebase, we've implemented expose loader to load some "externals". Those externals went through `babel-loader`, then `expose-loader`.
Some of the index files were written in ES6 and were not transpiled into ES5 compatible syntex by babel-loader. We've debugged and found the new entry files (e.g. `-!index.js`) were not indexed by babel and did not get compiled. Switching the rules order ensures the next rule can pick up all the files introduced by `expose-loader`.

Also fixed the link to CONTRIBUTING file.