### PR TITLE
fix: do not depend on Node.js global polyfill

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ function accesorString(value) {
   const childProperties = value.split('.');
   const { length } = childProperties;
   let propertyString = 'global';
-  let result = '';
+  let result =
+    "var global = (typeof window !== 'undefined' ? window : global);\n";
 
   for (let i = 0; i < length; i++) {
     if (i > 0) result += `if(!${propertyString}) ${propertyString} = {};\n`;


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
In light of webpack 5 [not polyfilling Node.js by default](https://github.com/webpack/changelog-v5#automatic-nodejs-polyfills-removed) 
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
Ideally [globalThis](https://github.com/tc39/proposal-global) should be used once it's added to the spec