### PR TITLE
Fix expose-loader failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,6 @@ So the expose only applies to the `jquery` module. And it's only exposed when us
 
 Please take a moment to read our contributing guidelines if you haven't yet done so.
 
-## Contributing
-
-Please take a moment to read our contributing guidelines if you haven't yet done so.
-
 [CONTRIBUTING](./.github/CONTRIBUTING.md)
 
 ## License

--- a/test/helpers/readAsset.js
+++ b/test/helpers/readAsset.js
@@ -10,7 +10,7 @@ export default (asset, compiler, stats) => {
   const queryStringIdx = targetFile.indexOf('?');
 
   if (queryStringIdx >= 0) {
-    targetFile = targetFile.substr(0, queryStringIdx);
+    targetFile = targetFile.substring(0, queryStringIdx + 1);
   }
 
   try {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Webpack (4.43.0) fails to build when requiring `expose-loader`. The error message output references the failure is due to a legacy function `substr`. This replaces `substr` with `substring`.
and also makes a minor update to the docs, removing a duplicate line.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
