### PR TITLE
Don't strip loader "ref" from import string

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -95,7 +95,7 @@ function contextify(context, request) {
   return request
     .split('!')
     .map((r) => {
-      const splitPath = r.split('?', 2);
+      const splitPath = r.split('?');
 
       if (/^[a-zA-Z]:\\/.test(splitPath[0])) {
         splitPath[0] = path.win32.relative(context, splitPath[0]);

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -349,6 +349,35 @@ Object {
 
 exports[`loader should work from esModule export: warnings 1`] = `Array []`;
 
+exports[`loader should work inline 1 with config loader options: errors 1`] = `Array []`;
+
+exports[`loader should work inline 1 with config loader options: module 1`] = `
+"var ___EXPOSE_LOADER_IMPORT___ = require(\\"-!../../node_modules/babel-loader/lib/index.js??{{config-reference}}!./global-commonjs2-single-export.js\\");
+var ___EXPOSE_LOADER_GET_GLOBAL_THIS___ = require(\\"../../src/runtime/getGlobalThis.js\\");
+var ___EXPOSE_LOADER_GLOBAL_THIS___ = ___EXPOSE_LOADER_GET_GLOBAL_THIS___;
+if (typeof ___EXPOSE_LOADER_GLOBAL_THIS___[\\"myGlobal\\"] === 'undefined') ___EXPOSE_LOADER_GLOBAL_THIS___[\\"myGlobal\\"] = ___EXPOSE_LOADER_IMPORT___;
+else throw new Error('[exposes-loader] The \\"myGlobal\\" value exists in the global scope, it may not be safe to overwrite it, use the \\"override\\" option')
+module.exports = ___EXPOSE_LOADER_IMPORT___;
+"
+`;
+
+exports[`loader should work inline 1 with config loader options: result 1`] = `
+Object {
+  "ExposeLoader": Object {
+    "default": Object {
+      "exposedEqualsGlobal": true,
+      "exposedEqualsImported": true,
+      "importedEqualsGlobal": true,
+    },
+  },
+  "myGlobal": Object {
+    "foo": "bar",
+  },
+}
+`;
+
+exports[`loader should work inline 1 with config loader options: warnings 1`] = `Array []`;
+
 exports[`loader should work inline 1 without extension: errors 1`] = `Array []`;
 
 exports[`loader should work inline 1 without extension: module 1`] = `

--- a/test/fixtures/inline-import-equality.js
+++ b/test/fixtures/inline-import-equality.js
@@ -1,0 +1,9 @@
+import exposed from '../../src/cjs.js?exposes=myGlobal!./global-commonjs2-single-export.js';
+
+import imported from './global-commonjs2-single-export.js'
+
+export default {
+  exposedEqualsGlobal: exposed === myGlobal,
+  importedEqualsGlobal: imported === myGlobal,
+  exposedEqualsImported: exposed === imported,
+}

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -390,7 +390,7 @@ describe('loader', () => {
     ).toMatchSnapshot('module');
     expect(module.hash).toBe(
       isWebpack5
-        ? 'ca629829313dd6de9e673c154aa723c4'
+        ? '53b5c93a2ac82d2e55921ab5bcf9649e'
         : 'c3e516476bee11406ecca2a29b66c743'
     );
     expect(getErrors(stats)).toMatchSnapshot('errors');

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -268,6 +268,48 @@ describe('loader', () => {
     expect(getWarnings(stats)).toMatchSnapshot('warnings');
   });
 
+  it('should work inline 1 with config loader options', async () => {
+    const compiler = getCompiler(
+      'inline-import-equality.js',
+      {},
+      {
+        devtool: 'source-map',
+        module: {
+          rules: [
+            {
+              test: /.*global-commonjs2-single-export\.js/i,
+              use: [
+                {
+                  loader: 'babel-loader',
+                  options: {
+                    presets: ['@babel/preset-env'],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }
+    );
+    const stats = await compile(compiler);
+
+    const isWebpack5 = webpack.version[0] === '5';
+    const refRegexp = isWebpack5 ? /\?ruleSet\[\d+\].*!/ : /\?ref--[0-9-]+!/;
+
+    expect(
+      getModuleSource(
+        './global-commonjs2-single-export-exposed.js',
+        stats
+      ).replace(refRegexp, '?{{config-reference}}!')
+    ).toMatchSnapshot('module');
+    expect(
+      execute(readAsset('main.bundle.js', compiler, stats))
+    ).toMatchSnapshot('result');
+    expect(readAsset('main.bundle.js.map', compiler, stats)).toBeDefined();
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+  });
+
   it('should work inline 1 without extension', async () => {
     const compiler = getCompiler(
       'inline-import-1.js',


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The remaining request could contain inline loaders with what looks like a reference to a loader defined in the webpack config: 
`"{loader_name}?{options}?ref--{loader_ref}!{imported-file}"`

`"C:\{project_path}\node_modules\babel-loader\lib\index.js??ref--5-oneOf-3!C:\{project_path}\node_modules\jquery\dist\jquery.js"`

`contextify` would split the string on `"?"` with a limit of 2, and therefore the reference is stripped.

Without the reference the result was that importing "jquery" both with expose-loader and without would result in two separate instances of jQuery. This made loading jQuery plugins on the exposed instance difficult, and also resulted in jQuery being included in the output bundle twice.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

None that I can think of.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

This likely also fixes #114.