### PR TITLE
docs: mention v4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ To begin, you'll need to install `expose-loader`:
 $ npm install expose-loader --save-dev
 ```
 
+(If you're using WebPack 4, install `expose-loader@1` and follow the [corresponding instructions](https://v4.webpack.js.org/loaders/expose-loader/) instead.)
+
 Then you can use the `expose-loader` using two approaches.
 
 ## Inline


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**
- [x] **documentation fix**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Following the instructions at https://v4.webpack.js.org/loaders/expose-loader/ and then https://github.com/webpack-contrib/expose-loader/ leads to a non-functional configuration for v4 users and, unless one is familiar enough with WebPack APIs to interpret the error message, no clue why. 

This small change should give a just-in-time heads-up.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None.

### Additional Info
