### PR TITLE
feat: add globalObject option to modify global context

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ And run `webpack` via your preferred method.
 
 ## Options
 
-|           Name            |                   Type                    |   Default   | Description     |
-| :-----------------------: | :---------------------------------------: | :---------: | :-------------- |
-| **[`exposes`](#exposes)** | `{String\|Object\|Array<String\|Object>}` | `undefined` | List of exposes |
+|                Name                 |                   Type                    |   Default   | Description                    |
+| :---------------------------------: | :---------------------------------------: | :---------: | :----------------------------- |
+|      **[`exposes`](#exposes)**      | `{String\|Object\|Array<String\|Object>}` | `undefined` | List of exposes                |
+| **[`globalObject`](#globalObject)** |                 `String`                  | `undefined` | Object used for global context |
 
 ### `exposes`
 
@@ -359,6 +360,43 @@ module.exports = {
 It will expose **only** `map`, `filter` and `find` (under `myNameForFind` name) methods to the global object.
 
 In a browser these methods will be available under `windows._.map(..args)`, `windows._.filter(...args)` and `windows._.myNameForFind(...args)` methods.
+
+### `globalObject`
+
+```ts
+type globalObject = string;
+```
+
+Default: `undefined`
+
+Object used for global context
+
+```js
+import _ from "underscore";
+```
+
+**webpack.config.js**
+
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: require.resolve("underscore"),
+        loader: "expose-loader",
+        options: {
+          exposes: [
+            {
+              globalName: "_",
+            },
+          ],
+          globalObject: "this",
+        },
+      },
+    ],
+  },
+};
+```
 
 ## Contributing
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,10 +53,14 @@ export default function loader() {
 
   let code = `var ___EXPOSE_LOADER_IMPORT___ = require(${stringifiedNewRequest});\n`;
 
-  code += `var ___EXPOSE_LOADER_GET_GLOBAL_THIS___ = require(${stringifyRequest(
-    this,
-    require.resolve("./runtime/getGlobalThis.js")
-  )});\n`;
+  const getGlobalThis =
+    options.globalObject ||
+    `require(${stringifyRequest(
+      this,
+      require.resolve("./runtime/getGlobalThis.js")
+    )})`;
+
+  code += `var ___EXPOSE_LOADER_GET_GLOBAL_THIS___ = ${getGlobalThis};\n`;
   code += `var ___EXPOSE_LOADER_GLOBAL_THIS___ = ___EXPOSE_LOADER_GET_GLOBAL_THIS___;\n`;
 
   for (const expose of exposes) {

--- a/src/options.json
+++ b/src/options.json
@@ -40,6 +40,11 @@
   },
   "type": "object",
   "properties": {
+    "globalObject": {
+      "type": "string",
+      "description": "Global object used as global context",
+      "link": "https://github.com/webpack-contrib/expose-loader#globalObject"
+    },
     "exposes": {
       "anyOf": [
         {
@@ -69,6 +74,5 @@
       "link": "https://github.com/webpack-contrib/expose-loader#exposes"
     }
   },
-  "anyOf": [{ "required": ["exposes"] }],
-  "additionalProperties": false
+  "anyOf": [{ "required": ["exposes"] }]
 }

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -974,6 +974,10 @@ exports[`loader should work with ES module format when module in ES format: resu
 
 exports[`loader should work with ES module format when module in ES format: warnings 1`] = `[]`;
 
+exports[`loader should work with globalObject: errors 1`] = `[]`;
+
+exports[`loader should work with globalObject: warnings 1`] = `[]`;
+
 exports[`loader should work with multiple exposes: errors 1`] = `[]`;
 
 exports[`loader should work with multiple exposes: module 1`] = `

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -761,4 +761,22 @@ describe("loader", () => {
     expect(getErrors(stats)).toMatchSnapshot("errors");
     expect(getWarnings(stats)).toMatchSnapshot("warnings");
   });
+
+  it("should work with globalObject", async () => {
+    const compiler = getCompiler("global-module-es.js", {
+      exposes: {
+        globalName: "FOO",
+        moduleLocalName: "default",
+      },
+      globalObject: "this",
+    });
+    const stats = await compile(compiler);
+
+    expect(readAsset("main.bundle.js", compiler, stats)).toContain(
+      "var ___EXPOSE_LOADER_GET_GLOBAL_THIS___ = this;\n"
+    );
+
+    expect(getErrors(stats)).toMatchSnapshot("errors");
+    expect(getWarnings(stats)).toMatchSnapshot("warnings");
+  });
 });


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

There are custom JS engines out there that seal the `globalThis` object. By default, this will break the assignment of the object we want to make global into the global context.

This PR gives the power to the user to override the default and choose the global object of their choosing.

### Breaking Changes

There should be no breaking changes.

### Additional Info

Addresses #203

